### PR TITLE
Change the color of the number of the selected "tag" to "orange"

### DIFF
--- a/.config/tint2/tint2rc
+++ b/.config/tint2/tint2rc
@@ -166,7 +166,9 @@ taskbar_name_background_id = 0
 taskbar_name_active_background_id = 1
 taskbar_name_font = Cantarell 9
 taskbar_name_font_color = #dddddd 100
-taskbar_name_active_font_color = #ffffff 100
+# Change the color of the number of the selected "tag" to "orange"
+# taskbar_name_active_font_color = #ffffff 100
+taskbar_name_active_font_color = #f57900 100
 taskbar_distribute_size = 1
 taskbar_sort_order = none
 task_align = left


### PR DESCRIPTION
Changed the color of the selected number to make it easier to understand.

Image of taskbar after change:

![worm-taskbar-color](https://user-images.githubusercontent.com/46095926/212521452-0c47bd17-f5cd-4cd8-889d-c005b842c46a.jpg)
